### PR TITLE
Update 2-lambda-function.md

### DIFF
--- a/instructions/2-lambda-function.md
+++ b/instructions/2-lambda-function.md
@@ -9,7 +9,7 @@ In the [first step of this guide](1-voice-user-interface.md), we built the Voice
 
 > Note: if you don't want to step through the detailed setup steps, click [here](https://console.aws.amazon.com/lambda/home?region=us-east-1#/create/app?applicationId=arn:aws:serverlessrepo:us-east-1:173334852312:applications/alexa-skills-kit-python36-factskill) to create the function from a Serverless Application Repository template.  Then skip to the final step below and copy the ARN.
 
-1.  **Go to http://aws.amazon.com and sign in to the console.** If you don't already have an account, you will need to create one.  [Check out this quick walkthrough for setting up a new AWS account](https://github.com/alexa/alexa-cookbook/blob/master/aws/set-up-aws.md).
+1.  **Go to http://aws.amazon.com and sign in to the console.** If you don't already have an account, you will need to create one.  [Check out this quick walkthrough for setting up a new AWS account](https://github.com/alexa/alexa-cookbook/blob/master/guides/aws-security-and-setup/set-up-aws.md).
 
     [![Sign In](https://m.media-amazon.com/images/G/01/mobile-apps/dex/alexa/alexa-skills-kit/tutorials/general/2-1-sign-in-to-the-console._TTH_.png)](https://console.aws.amazon.com/console/home)
 


### PR DESCRIPTION
URL for the walkthrough guide for setting up a new AWS account was not found (404) as it has been moved to a new location.

*Issue #, if available:*
A guide's URL is now a 404. 

*Description of changes:*
A new URL has been added.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.